### PR TITLE
Makefile.in: add gsl/gsl_math.cmo gsl/gsl_sf.cmo to GSL_CMO

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -81,7 +81,7 @@ CURSES_OOBJS = $(CURSES_CMX) $(CURSES_COBJS)
 GSL_CMO = gsl/gsl_error.cmo gsl/gsl_blas.cmo gsl/gsl_complex.cmo gsl/gsl_matrix.cmo gsl/gsl_matrix_complex.cmo \
 		gsl/gsl_vector.cmo gsl/gsl_vector_complex.cmo gsl/gsl_vector_flat.cmo gsl/gsl_matrix_flat.cmo \
 		gsl/gsl_vector_complex_flat.cmo gsl/gsl_matrix_complex_flat.cmo gsl/gsl_vectmat.cmo \
-		gsl/gsl_permut.cmo gsl/gsl_linalg.cmo gsl/gsl_fun.cmo
+		gsl/gsl_permut.cmo gsl/gsl_linalg.cmo gsl/gsl_fun.cmo gsl/gsl_math.cmo gsl/gsl_sf.cmo
 GSL_CMX = $(GSL_CMO:.cmo=.cmx)
 GSL_COBJS = gsl/mlgsl_error.o gsl/mlgsl_blas.o gsl/mlgsl_blas_complex.o gsl/mlgsl_complex.o gsl/mlgsl_blas_float.o \
 		 gsl/mlgsl_blas_complex_float.o gsl/mlgsl_matrix_complex.o gsl/mlgsl_matrix_double.o gsl/mlgsl_matrix_float.o \


### PR DESCRIPTION
@pelzlpj see #1 for context. I'm not sure if this is generally applicable or only needed in my environment: I don't know enough about gsl or ocaml to have an opinion. But without this change I can't get past this error:

```
Error: No implementations provided for the following modules:
         Gsl_sf referenced from rpc_calc.cmx
         Gsl_math referenced from rpc_calc.cmx
```
