### PR TITLE
Incorrect constant

### DIFF
--- a/etc/orpierc
+++ b/etc/orpierc
@@ -325,7 +325,7 @@ constant "e"      "1.60217733e-19_C"
 # electronic mass
 constant "me"     "9.1093897e-31_kg"
 # proton mass
-constant "mp"     "1.6726231e-17_kg"
+constant "mp"     "1.6726231e-27_kg"
 # fine structure constant
 constant "alpha"  "0.00729735308"
 # magnetic flux quantum


### PR DESCRIPTION
Hi! It seems like the proton mass has wrong magnitude. I think it should be e-27, not e-17.

I really enjoy using Orpie, thanks!