### PR TITLE
Don't crash on resize, plus others

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,39 @@
+FROM ocaml/opam:debian-11
+
+LABEL mantainer="Leonardo Amaral <dev@leonardoamaral.com.br>"
+
+USER root:root
+ENV HOME=/root
+WORKDIR /root
+
+RUN DEBIAN_FRONTEND=noninteractive apt -y update \
+	&& DEBIAN_FRONTEND=noninteractive apt -y install libstring-shellquote-perl libipc-system-simple-perl pkg-config libgsl-dev libncurses-dev \
+	&& DEBIAN_FRONTEND=noninteractive apt clean \
+	&& rm -rf /var/cache/apt/lists/*
+
+USER opam:opam
+ENV HOME=/home/opam
+WORKDIR /home/opam
+
+RUN opam install dune camlp5 ocamlfind curses gsl num
+
+RUN git clone https://github.com/pelzlpj/orpie.git \
+	&& cd orpie \
+	&& eval $(opam config env) \
+	&& make install \
+	&& cd .. \
+	&& rm -rf orpie
+
+USER root:root
+ENV HOME=/root
+WORKDIR /root
+
+RUN apt -y purge pkg-config libgsl-dev libncurses-dev
+
+USER opam:opam
+ENV HOME=/home/opam
+WORKDIR /home/opam
+
+COPY --chown=opam:opam --chmod=0755 ./docker-entrypoint.sh /docker-entrypoint.sh
+
+ENTRYPOINT /docker-entrypoint.sh orpie

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ENV HOME=/root
 WORKDIR /root
 
 RUN DEBIAN_FRONTEND=noninteractive apt -y update \
-	&& DEBIAN_FRONTEND=noninteractive apt -y install libstring-shellquote-perl libipc-system-simple-perl pkg-config libgsl-dev libncurses-dev \
+	&& DEBIAN_FRONTEND=noninteractive apt -y install libstring-shellquote-perl libipc-system-simple-perl pkg-config libgsl-dev libncurses-dev m4 \
 	&& DEBIAN_FRONTEND=noninteractive apt clean \
 	&& rm -rf /var/cache/apt/lists/*
 
@@ -15,9 +15,9 @@ USER opam:opam
 ENV HOME=/home/opam
 WORKDIR /home/opam
 
-RUN opam install dune camlp5 ocamlfind curses gsl num
+RUN opam install dune camlp5 ocamlfind curses gsl num camlp-streams
 
-RUN git clone https://github.com/pelzlpj/orpie.git \
+RUN git clone https://github.com/erhannis/orpie.git \
 	&& cd orpie \
 	&& eval $(opam config env) \
 	&& make install \

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,9 @@ install: _build/install/default/bin/orpie _build/install/default/bin/orpie-curse
 	mkdir -p "$(DESTDIR)/$$ORPIE_PREFIX" && \
 	dune install --prefix="$(DESTDIR)/$$ORPIE_PREFIX"
 
+docker:
+	docker build -t orpie:latest .
+
 clean:
 	dune clean
 

--- a/README.adoc
+++ b/README.adoc
@@ -34,6 +34,10 @@ $ make
 $ make install
 ----
 
+=== Using Docker image
+
+A Dockerfile is available to automatize orpie usage. Image can be built running `make docker` and the command to run is `docker run -it --name orpie --rm orpie:latest`.
+
 == Usage
 See the 'doc' subdirectory for more extensive documentation.
 

--- a/doc/manual.html
+++ b/doc/manual.html
@@ -1173,6 +1173,10 @@ is complementary to <span style="font-family:monospace">browse_dropn</span>.
  Move the selection cursor down one line.
 </li><li class="li-itemize"><span style="font-family:monospace">browse_prev_line</span> <br>
  Move the selection cursor up one line.
+</li><li class="li-itemize"><span style="font-family:monospace">browse_swapdown</span> <br>
+ Swap the selected stack element downward.
+</li><li class="li-itemize"><span style="font-family:monospace">browse_swapup</span> <br>
+ Swap the selected stack element upward.
 </li><li class="li-itemize"><span style="font-family:monospace">browse_rolldown</span> <br>
  Cyclically &#X201C;roll&#X201D; stack elements downward, below the 
 selected element (inclusive).

--- a/doc/orpierc.5
+++ b/doc/orpierc.5
@@ -938,6 +938,16 @@ browse_prev_line
 Move the selection cursor up one line. 
 .TP
 .B *
+browse_swapdown 
+.br 
+Swap the selected stack element downward.
+.TP
+.B *
+browse_swapup 
+.br 
+Swap the selected stack element upward.
+.TP
+.B *
 browse_rolldown 
 .br 
 Cyclically ``roll\&'' stack elements downward, below the 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+eval $(opam config env)
+exec "$@"

--- a/etc/orpierc
+++ b/etc/orpierc
@@ -76,6 +76,8 @@ bind "<left>"         browse_scroll_left
 bind "<right>"        browse_scroll_right
 bind "<up>"           browse_prev_line
 bind "<down>"         browse_next_line
+bind \1015            browse_swapdown
+bind \1066            browse_swapup
 bind "r"              browse_rolldown
 bind "R"              browse_rollup
 bind "v"              browse_view

--- a/etc/orpierc
+++ b/etc/orpierc
@@ -325,7 +325,7 @@ constant "e"      "1.60217733e-19_C"
 # electronic mass
 constant "me"     "9.1093897e-31_kg"
 # proton mass
-constant "mp"     "1.6726231e-17_kg"
+constant "mp"     "1.6726231e-27_kg"
 # fine structure constant
 constant "alpha"  "0.00729735308"
 # magnetic flux quantum

--- a/etc/orpierc
+++ b/etc/orpierc
@@ -76,8 +76,8 @@ bind "<left>"         browse_scroll_left
 bind "<right>"        browse_scroll_right
 bind "<up>"           browse_prev_line
 bind "<down>"         browse_next_line
-bind \1015            browse_swapdown
-bind \1066            browse_swapup
+bind \1057            browse_swapdown
+bind \1064            browse_swapup
 bind "r"              browse_rolldown
 bind "R"              browse_rollup
 bind "v"              browse_view

--- a/orpie.opam
+++ b/orpie.opam
@@ -15,6 +15,7 @@ depends: [
   "curses" {>= "1.0.3"}
   "gsl" {>= "1.22.0"}
   "num"
+  "camlp-streams"
 ]
 synopsis: "Curses-based RPN calculator"
 description: """

--- a/src/orpie/dune
+++ b/src/orpie/dune
@@ -5,7 +5,7 @@
     (action
       (system "camlp5o %{input-file}")))
   (flags (:standard -w -27-35-52 -thread))
-  (libraries curses gsl num str threads))
+  (libraries curses gsl num str threads camlp-streams))
 
 
 ; Use orpie.opam as the authoritative source of version number

--- a/src/orpie/interface.ml
+++ b/src/orpie/interface.ml
@@ -33,7 +33,8 @@ exception Not_handled;;
 type screen_t = {stdscr:window; mutable lines:int; mutable cols:int;
    mutable help_win:window option; mutable hw_lines:int; mutable hw_cols:int;
    mutable stack_win:window; mutable sw_lines:int; mutable sw_cols:int; 
-   mutable entry_win:window; mutable ew_lines:int; mutable ew_cols:int};;
+   mutable entry_win:window; mutable ew_lines:int; mutable ew_cols:int;
+   mutable is_paused : bool};;
 
 type entry_t     = | IntEntry | FloatEntry | ComplexEntry 
                    | FloatMatrixEntry | ComplexMatrixEntry | VarEntry;;

--- a/src/orpie/interface_draw.ml
+++ b/src/orpie/interface_draw.ml
@@ -654,25 +654,29 @@ let draw_help_browsing iface win mvwaddstr_safe try_find =
    try_find (Browse ScrollLeft));
    mvwaddstr_safe win 9 2  ("scroll right: " ^
    try_find (Browse ScrollRight));
-   mvwaddstr_safe win 10 2 ("roll down   : " ^
+   mvwaddstr_safe win 10 2 ("swap down   : " ^
+   try_find (Browse SwapDown));
+   mvwaddstr_safe win 11 2 ("swap up     : " ^
+   try_find (Browse SwapUp));
+   mvwaddstr_safe win 12 2 ("roll down   : " ^
    try_find (Browse RollDown));
-   mvwaddstr_safe win 11 2 ("roll up     : " ^
+   mvwaddstr_safe win 13 2 ("roll up     : " ^
    try_find (Browse RollUp));
-   mvwaddstr_safe win 12 2 ("dup         : " ^
+   mvwaddstr_safe win 14 2 ("dup         : " ^
    try_find (Command Dup));
-   mvwaddstr_safe win 13 2 ("view        : " ^
+   mvwaddstr_safe win 15 2 ("view        : " ^
    try_find (Browse ViewEntry));
-   mvwaddstr_safe win 14 2 ("edit        : " ^
+   mvwaddstr_safe win 16 2 ("edit        : " ^
    try_find (Browse EditEntry));
-   mvwaddstr_safe win 15 2 ("drop        : " ^
+   mvwaddstr_safe win 17 2 ("drop        : " ^
    try_find (Browse Drop1));
-   mvwaddstr_safe win 16 2 ("dropn       : " ^
+   mvwaddstr_safe win 18 2 ("dropn       : " ^
    try_find (Browse DropN));
-   mvwaddstr_safe win 17 2 ("keep        : " ^
+   mvwaddstr_safe win 19 2 ("keep        : " ^
    try_find (Browse Keep));
-   mvwaddstr_safe win 18 2 ("keepn       : " ^
+   mvwaddstr_safe win 20 2 ("keepn       : " ^
    try_find (Browse KeepN));
-   mvwaddstr_safe win 20 1 ("exit browsing mode: " ^
+   mvwaddstr_safe win 22 1 ("exit browsing mode: " ^
    try_find (Browse EndBrowse));
    assert (wnoutrefresh win)
 

--- a/src/orpie/interface_draw.ml
+++ b/src/orpie/interface_draw.ml
@@ -36,100 +36,108 @@ type abbrev_help_display_t = {functions : string list;
 (* display the stack, where the bottom line of the display
  * corresponds to stack level 'stack_bottom_row' *)
 let draw_stack (iface : interface_state_t) =
-   let print_numbered_line l_num =
-      let num_len = 
-         String.length (string_of_int (pred (iface.stack_bottom_row +
-         iface.scr.sw_lines)))
+   if iface.scr.is_paused then
+   begin
+      Printf.fprintf stderr "Orpie requires at least an 80x24 line window.\r\n";
+      flush stderr;
+   end
+   else
+   begin
+      let print_numbered_line l_num =
+          let num_len = 
+            String.length (string_of_int (pred (iface.stack_bottom_row +
+            iface.scr.sw_lines)))
+          in
+          if num_len <= 2 then
+            (sprintf "%2d:   %s" l_num)
+          else if num_len = 3 then
+            (sprintf "%3d:  %s" l_num)
+          else if num_len = 4 then
+            (sprintf "%4d: %s" l_num)
+          else
+            (* if the line number is really huge, truncate to least
+              * significant digits *)
+            let l_num_str = string_of_int l_num in
+            let str_len = String.length l_num_str in
+            let trunc_num = Str.string_after l_num_str (str_len - 4) in
+            (sprintf "%s: %s" trunc_num)
       in
-      if num_len <= 2 then
-         (sprintf "%2d:   %s" l_num)
-      else if num_len = 3 then
-         (sprintf "%3d:  %s" l_num)
-      else if num_len = 4 then
-         (sprintf "%4d: %s" l_num)
-      else
-         (* if the line number is really huge, truncate to least
-          * significant digits *)
-         let l_num_str = string_of_int l_num in
-         let str_len = String.length l_num_str in
-         let trunc_num = Str.string_after l_num_str (str_len - 4) in
-         (sprintf "%s: %s" trunc_num)
-   in
-   (* if there is no help window, then print the calculator mode
-    * information above the stack *)
-   let num_stack_lines =
-      begin match iface.scr.help_win with
-      |Some win ->
-         iface.scr.sw_lines
-      |None ->
-         let modes = iface.calc#get_modes () in
-         assert (wmove iface.scr.stack_win 0 0);
-         wclrtoeol iface.scr.stack_win;
-         wattron iface.scr.stack_win WA.bold;
-         assert (mvwaddstr iface.scr.stack_win 0 2 "angle:      base:      complex:");
-         wattroff iface.scr.stack_win WA.bold;
-         let angle_str = match modes.angle with
-         |Rad -> "RAD"
-         |Deg -> "DEG" in
-         assert (mvwaddstr iface.scr.stack_win 0 9 angle_str);
-         let base_str = match modes.base with
-         |Bin -> "BIN"
-         |Oct -> "OCT"
-         |Hex -> "HEX"
-         |Dec -> "DEC" in
-         assert (mvwaddstr iface.scr.stack_win 0 20 base_str);
-         let complex_str = match modes.complex with
-         |Rect -> "REC"
-         |Polar -> "POL" in
-         assert (mvwaddstr iface.scr.stack_win 0 34 complex_str);
-         assert (mvwaddstr iface.scr.stack_win 1 0 (String.make (iface.scr.sw_cols) '-'));
-         iface.scr.sw_lines - 2
-      end
-   in
-   (* display the stack data itself *)
-   for line = iface.stack_bottom_row to 
-   pred (iface.stack_bottom_row + num_stack_lines) do
-      let s = iface.calc#get_display_line line in
-      let len = String.length s in
-      assert (wmove iface.scr.stack_win 
-      (iface.scr.sw_lines + iface.stack_bottom_row - 1 - line) 0);
-      wclrtoeol iface.scr.stack_win;
-      if line = iface.stack_selection && 
-      iface.interface_mode = BrowsingMode then
-         wattron iface.scr.stack_win WA.reverse
-      else
-         ();
-      if len > iface.scr.sw_cols - 7 then begin
-         (* need to truncate the string *)
-         let line_string =
-            if line = iface.stack_selection && 
-            iface.interface_mode = BrowsingMode then
-               let sub_s = 
-                  if iface.horiz_scroll < len - iface.scr.sw_cols + 7 then
-                     String.sub s iface.horiz_scroll (iface.scr.sw_cols - 7)
-                  else
-                     String.sub s (len - iface.scr.sw_cols + 7) 
-                     (iface.scr.sw_cols - 7)
-               in
-               print_numbered_line line sub_s
-            else
-               let sub_s = String.sub s 0 (iface.scr.sw_cols - 10) in
-               print_numbered_line line (sub_s ^ "...")
-         in
-         assert (waddstr iface.scr.stack_win line_string)
-      end else begin
-         let spacer = String.make (iface.scr.sw_cols - 7 - len) ' ' in
-         let line_string = print_numbered_line line (spacer ^ s) in 
-         assert (waddstr iface.scr.stack_win line_string)
-      end;
-      if line = iface.stack_selection && 
-      iface.interface_mode = BrowsingMode then
-         wattroff iface.scr.stack_win WA.reverse
-      else
-         ();
-   done;
-   assert (wnoutrefresh iface.scr.stack_win);
-   assert (wmove iface.scr.entry_win (iface.scr.ew_lines - 1) (iface.scr.ew_cols - 1))
+      (* if there is no help window, then print the calculator mode
+        * information above the stack *)
+      let num_stack_lines =
+          begin match iface.scr.help_win with
+          |Some win ->
+            iface.scr.sw_lines
+          |None ->
+            let modes = iface.calc#get_modes () in
+            assert (wmove iface.scr.stack_win 0 0);
+            wclrtoeol iface.scr.stack_win;
+            wattron iface.scr.stack_win WA.bold;
+            assert (mvwaddstr iface.scr.stack_win 0 2 "angle:      base:      complex:");
+            wattroff iface.scr.stack_win WA.bold;
+            let angle_str = match modes.angle with
+            |Rad -> "RAD"
+            |Deg -> "DEG" in
+            assert (mvwaddstr iface.scr.stack_win 0 9 angle_str);
+            let base_str = match modes.base with
+            |Bin -> "BIN"
+            |Oct -> "OCT"
+            |Hex -> "HEX"
+            |Dec -> "DEC" in
+            assert (mvwaddstr iface.scr.stack_win 0 20 base_str);
+            let complex_str = match modes.complex with
+            |Rect -> "REC"
+            |Polar -> "POL" in
+            assert (mvwaddstr iface.scr.stack_win 0 34 complex_str);
+            assert (mvwaddstr iface.scr.stack_win 1 0 (String.make (iface.scr.sw_cols) '-'));
+            iface.scr.sw_lines - 2
+          end
+      in
+      (* display the stack data itself *)
+      for line = iface.stack_bottom_row to 
+      pred (iface.stack_bottom_row + num_stack_lines) do
+          let s = iface.calc#get_display_line line in
+          let len = String.length s in
+          assert (wmove iface.scr.stack_win 
+          (iface.scr.sw_lines + iface.stack_bottom_row - 1 - line) 0);
+          wclrtoeol iface.scr.stack_win;
+          if line = iface.stack_selection && 
+          iface.interface_mode = BrowsingMode then
+            wattron iface.scr.stack_win WA.reverse
+          else
+            ();
+          if len > iface.scr.sw_cols - 7 then begin
+            (* need to truncate the string *)
+            let line_string =
+                if line = iface.stack_selection && 
+                iface.interface_mode = BrowsingMode then
+                  let sub_s = 
+                      if iface.horiz_scroll < len - iface.scr.sw_cols + 7 then
+                        String.sub s iface.horiz_scroll (iface.scr.sw_cols - 7)
+                      else
+                        String.sub s (len - iface.scr.sw_cols + 7) 
+                        (iface.scr.sw_cols - 7)
+                  in
+                  print_numbered_line line sub_s
+                else
+                  let sub_s = String.sub s 0 (iface.scr.sw_cols - 10) in
+                  print_numbered_line line (sub_s ^ "...")
+            in
+            assert (waddstr iface.scr.stack_win line_string)
+          end else begin
+            let spacer = String.make (iface.scr.sw_cols - 7 - len) ' ' in
+            let line_string = print_numbered_line line (spacer ^ s) in 
+            assert (waddstr iface.scr.stack_win line_string)
+          end;
+          if line = iface.stack_selection && 
+          iface.interface_mode = BrowsingMode then
+            wattroff iface.scr.stack_win WA.reverse
+          else
+            ();
+      done;
+      assert (wnoutrefresh iface.scr.stack_win);
+      assert (wmove iface.scr.entry_win (iface.scr.ew_lines - 1) (iface.scr.ew_cols - 1))
+   end
 
 
 let draw_update_stack iface =
@@ -141,192 +149,200 @@ let draw_update_stack iface =
 
 (* display the data that the user is in the process of entering *)
 let draw_entry (iface : interface_state_t) =
-   assert (mvwaddstr iface.scr.entry_win 0 0 (String.make iface.scr.ew_cols '-'));
-   assert (wmove iface.scr.entry_win 1 0);
-   wclrtoeol iface.scr.entry_win;
-   (* Safely draw a string into the entry window, with "..." when
-    * truncation occurs.  Highlight the first 'highlight_len'
-    * characters. *)
-   let draw_entry_string str highlight_len =
-      let len_str = String.length str in
-      begin
-         if len_str > iface.scr.ew_cols - 1 then
-            let trunc_str = String.sub str (len_str - iface.scr.ew_cols + 4) 
-            (iface.scr.ew_cols - 4) in
-            assert (mvwaddstr iface.scr.entry_win 1 0 ("..." ^ trunc_str))
-         else
-            if highlight_len <= len_str then
-               begin
-                  (* highlight the first 'highlight_len' characters *)
-                  wattron iface.scr.entry_win WA.bold;
-                  assert (mvwaddstr iface.scr.entry_win 1 (iface.scr.ew_cols - len_str - 1)
-                     (Str.string_before str (highlight_len)));
-                  wattroff iface.scr.entry_win WA.bold;
-                  assert (mvwaddstr iface.scr.entry_win 1 (iface.scr.ew_cols - len_str -
-                     1 + highlight_len) (Str.string_after str (highlight_len)))
-               end
+  if iface.scr.is_paused then
+  begin
+      Printf.fprintf stderr "Orpie requires at least an 80x24 line window.\r\n";
+      flush stderr;
+  end
+  else
+  begin
+      assert (mvwaddstr iface.scr.entry_win 0 0 (String.make iface.scr.ew_cols '-'));
+      assert (wmove iface.scr.entry_win 1 0);
+      wclrtoeol iface.scr.entry_win;
+      (* Safely draw a string into the entry window, with "..." when
+        * truncation occurs.  Highlight the first 'highlight_len'
+        * characters. *)
+      let draw_entry_string str highlight_len =
+          let len_str = String.length str in
+          begin
+            if len_str > iface.scr.ew_cols - 1 then
+                let trunc_str = String.sub str (len_str - iface.scr.ew_cols + 4) 
+                (iface.scr.ew_cols - 4) in
+                assert (mvwaddstr iface.scr.entry_win 1 0 ("..." ^ trunc_str))
             else
-               assert (mvwaddstr iface.scr.entry_win 1 (iface.scr.ew_cols - len_str - 1) str)
-      end;
-      assert (wnoutrefresh iface.scr.entry_win)
-   in
-   (* draw a string for a single floating-point number *)
-   let get_float_str is_current mantissa exponent =
-      let sign_space =
-         if String.length exponent > 0 then
-            match exponent.[0] with
-            |'-' -> ""
-            |'+' -> ""
-            |_ -> " "
-         else
-            " "
+                if highlight_len <= len_str then
+                  begin
+                      (* highlight the first 'highlight_len' characters *)
+                      wattron iface.scr.entry_win WA.bold;
+                      assert (mvwaddstr iface.scr.entry_win 1 (iface.scr.ew_cols - len_str - 1)
+                        (Str.string_before str (highlight_len)));
+                      wattroff iface.scr.entry_win WA.bold;
+                      assert (mvwaddstr iface.scr.entry_win 1 (iface.scr.ew_cols - len_str -
+                        1 + highlight_len) (Str.string_after str (highlight_len)))
+                  end
+                else
+                  assert (mvwaddstr iface.scr.entry_win 1 (iface.scr.ew_cols - len_str - 1) str)
+          end;
+          assert (wnoutrefresh iface.scr.entry_win)
       in
-      if (is_current && iface.is_entering_exponent) || String.length exponent > 0 then
-         mantissa ^ " x10^" ^ sign_space ^ exponent
-      else if is_current || String.length mantissa > 0 then
-         mantissa
-      else 
-         "0"
-   in
-   (* get a string representation of the data that is in the entry buffer *)
-   let data_string =
-      match iface.entry_type with
-      |IntEntry ->
-         if iface.is_entering_base then
-            "# " ^ iface.int_entry_buffer ^ "`" ^ iface.int_base_string
-         else
-            "# " ^ iface.int_entry_buffer
-      |FloatEntry ->
-         let mantissa_str = iface.gen_buffer.(0).re_mantissa
-         and exponent_str = iface.gen_buffer.(0).re_exponent in
-         let ff = get_float_str true mantissa_str exponent_str in
-         if iface.is_entering_units then
-            ff ^ "_" ^ iface.units_entry_buffer
-         else
-            ff
-      |ComplexEntry ->
-         let buffer = iface.gen_buffer.(0) in
-         let cc = 
-            if iface.is_entering_imag then
-               let temp = get_float_str false buffer.re_mantissa buffer.re_exponent in
-               let re_str = 
-                  if String.length temp > 0 then temp
-                  else "0"
-               in
-               let im_str = get_float_str true buffer.im_mantissa buffer.im_exponent in
-               match buffer.is_polar with
-               |false ->
-                  "(" ^ re_str ^ ", " ^ im_str ^ ")"
-               |true ->
-                  "(" ^ re_str ^ " <" ^ im_str ^ ")"
+      (* draw a string for a single floating-point number *)
+      let get_float_str is_current mantissa exponent =
+          let sign_space =
+            if String.length exponent > 0 then
+                match exponent.[0] with
+                |'-' -> ""
+                |'+' -> ""
+                |_ -> " "
             else
-               let re_str = get_float_str true buffer.re_mantissa buffer.re_exponent in
-               "(" ^ re_str ^ ")"
-         in
-         if iface.is_entering_units then
-            cc ^ "_" ^ iface.units_entry_buffer
-         else
-            cc
-      |FloatMatrixEntry ->
-         let ss = ref "[[" in
-         for el = 0 to pred iface.curr_buf do
-            let temp_re = get_float_str false iface.gen_buffer.(el).re_mantissa
-            iface.gen_buffer.(el).re_exponent in
-            if iface.has_multiple_rows && ((succ el) mod iface.matrix_cols) = 0 then
-               ss := !ss ^ temp_re ^ "]["
+                " "
+          in
+          if (is_current && iface.is_entering_exponent) || String.length exponent > 0 then
+            mantissa ^ " x10^" ^ sign_space ^ exponent
+          else if is_current || String.length mantissa > 0 then
+            mantissa
+          else 
+            "0"
+      in
+      (* get a string representation of the data that is in the entry buffer *)
+      let data_string =
+          match iface.entry_type with
+          |IntEntry ->
+            if iface.is_entering_base then
+                "# " ^ iface.int_entry_buffer ^ "`" ^ iface.int_base_string
             else
-               ss := !ss ^ temp_re ^ ", "
-         done;
-         let temp_re = get_float_str true iface.gen_buffer.(iface.curr_buf).re_mantissa
-         iface.gen_buffer.(iface.curr_buf).re_exponent in
-         ss := !ss ^ temp_re ^ "]]";
-         if iface.is_entering_units then
-            !ss ^ "_" ^ iface.units_entry_buffer
-         else
-            !ss
-      |ComplexMatrixEntry ->
-         let ss = ref "[[" in
-         for el = 0 to pred iface.curr_buf do
-            let temp_re = get_float_str false iface.gen_buffer.(el).re_mantissa
-            iface.gen_buffer.(el).re_exponent and
-            temp_im = get_float_str false iface.gen_buffer.(el).im_mantissa
-            iface.gen_buffer.(el).im_exponent in
-            (if iface.has_multiple_rows && ((succ el) mod iface.matrix_cols) = 0 then
-               match iface.gen_buffer.(el).is_polar with
-               |false ->
-                  ss := !ss ^ "(" ^ temp_re ^ ", " ^ temp_im ^ ")]["
-               |true ->
-                  ss := !ss ^ "(" ^ temp_re ^ " <" ^ temp_im ^ ")]["
+                "# " ^ iface.int_entry_buffer
+          |FloatEntry ->
+            let mantissa_str = iface.gen_buffer.(0).re_mantissa
+            and exponent_str = iface.gen_buffer.(0).re_exponent in
+            let ff = get_float_str true mantissa_str exponent_str in
+            if iface.is_entering_units then
+                ff ^ "_" ^ iface.units_entry_buffer
             else
-               match iface.gen_buffer.(el).is_polar with
-               |false ->
-                  ss := !ss ^ "(" ^ temp_re ^ ", " ^ temp_im ^ "), "
-               |true ->
-                  ss := !ss ^ "(" ^ temp_re ^ " <" ^ temp_im ^ "), ")
-         done;
-         (if iface.is_entering_imag then
-            let temp_re = get_float_str false iface.gen_buffer.(iface.curr_buf).re_mantissa
-            iface.gen_buffer.(iface.curr_buf).re_exponent and
-            temp_im = get_float_str true iface.gen_buffer.(iface.curr_buf).im_mantissa
-            iface.gen_buffer.(iface.curr_buf).im_exponent in
-            match iface.gen_buffer.(iface.curr_buf).is_polar with
-            |false ->
-               ss := !ss ^ "(" ^ temp_re ^ ", " ^ temp_im ^ ")]]"
-            |true ->
-               ss := !ss ^ "(" ^ temp_re ^ " <" ^ temp_im ^ ")]]"
-         else
+                ff
+          |ComplexEntry ->
+            let buffer = iface.gen_buffer.(0) in
+            let cc = 
+                if iface.is_entering_imag then
+                  let temp = get_float_str false buffer.re_mantissa buffer.re_exponent in
+                  let re_str = 
+                      if String.length temp > 0 then temp
+                      else "0"
+                  in
+                  let im_str = get_float_str true buffer.im_mantissa buffer.im_exponent in
+                  match buffer.is_polar with
+                  |false ->
+                      "(" ^ re_str ^ ", " ^ im_str ^ ")"
+                  |true ->
+                      "(" ^ re_str ^ " <" ^ im_str ^ ")"
+                else
+                  let re_str = get_float_str true buffer.re_mantissa buffer.re_exponent in
+                  "(" ^ re_str ^ ")"
+            in
+            if iface.is_entering_units then
+                cc ^ "_" ^ iface.units_entry_buffer
+            else
+                cc
+          |FloatMatrixEntry ->
+            let ss = ref "[[" in
+            for el = 0 to pred iface.curr_buf do
+                let temp_re = get_float_str false iface.gen_buffer.(el).re_mantissa
+                iface.gen_buffer.(el).re_exponent in
+                if iface.has_multiple_rows && ((succ el) mod iface.matrix_cols) = 0 then
+                  ss := !ss ^ temp_re ^ "]["
+                else
+                  ss := !ss ^ temp_re ^ ", "
+            done;
             let temp_re = get_float_str true iface.gen_buffer.(iface.curr_buf).re_mantissa
             iface.gen_buffer.(iface.curr_buf).re_exponent in
-            ss := !ss ^ "(" ^ temp_re ^ ")]]");
-         if iface.is_entering_units then
-            !ss ^ "_" ^ iface.units_entry_buffer
-         else
-            !ss
-      |VarEntry ->
-         "@ " ^ iface.variable_entry_buffer
-   in
-   begin match iface.interface_mode with
-   |StandardEditMode ->
-      draw_entry_string data_string 0
-   |IntEditMode ->
-      draw_entry_string data_string 0
-   |AbbrevEditMode ->
-      let first_abbrev_match =
-         if iface.matched_abbrev_list = [] then ""
-         else List.hd iface.matched_abbrev_list
-      in
-      let highlight_len = String.length iface.abbrev_entry_buffer in
-      if highlight_len = 0 then
-         begin match iface.abbrev_or_const with
-         |IsAbbrev -> draw_entry_string "<enter command abbreviation>" 0
-         |IsConst  -> draw_entry_string "<enter constant symbol>" 0
-         end
-      else
-         begin match iface.abbrev_or_const with
-         |IsAbbrev ->
-            let is_function =
-               match (Rcfile.translate_abbrev first_abbrev_match) with
-               |Function ff -> true
-               |_ -> false
-            in
-            if is_function then
-               draw_entry_string (first_abbrev_match ^ "( )") highlight_len
+            ss := !ss ^ temp_re ^ "]]";
+            if iface.is_entering_units then
+                !ss ^ "_" ^ iface.units_entry_buffer
             else
-               draw_entry_string first_abbrev_match highlight_len
-         |IsConst ->
-            draw_entry_string first_abbrev_match highlight_len
-         end
-   |BrowsingMode ->
-      ()
-   |VarEditMode ->
-      if String.length iface.variable_entry_buffer = 0 then
-         draw_entry_string "<enter variable name>" 0
-      else
-         draw_entry_string data_string 0
-   |UnitEditMode ->
-      draw_entry_string data_string 0
-   end;
-   assert (wmove iface.scr.entry_win (iface.scr.ew_lines - 1) (iface.scr.ew_cols - 1))
+                !ss
+          |ComplexMatrixEntry ->
+            let ss = ref "[[" in
+            for el = 0 to pred iface.curr_buf do
+                let temp_re = get_float_str false iface.gen_buffer.(el).re_mantissa
+                iface.gen_buffer.(el).re_exponent and
+                temp_im = get_float_str false iface.gen_buffer.(el).im_mantissa
+                iface.gen_buffer.(el).im_exponent in
+                (if iface.has_multiple_rows && ((succ el) mod iface.matrix_cols) = 0 then
+                  match iface.gen_buffer.(el).is_polar with
+                  |false ->
+                      ss := !ss ^ "(" ^ temp_re ^ ", " ^ temp_im ^ ")]["
+                  |true ->
+                      ss := !ss ^ "(" ^ temp_re ^ " <" ^ temp_im ^ ")]["
+                else
+                  match iface.gen_buffer.(el).is_polar with
+                  |false ->
+                      ss := !ss ^ "(" ^ temp_re ^ ", " ^ temp_im ^ "), "
+                  |true ->
+                      ss := !ss ^ "(" ^ temp_re ^ " <" ^ temp_im ^ "), ")
+            done;
+            (if iface.is_entering_imag then
+                let temp_re = get_float_str false iface.gen_buffer.(iface.curr_buf).re_mantissa
+                iface.gen_buffer.(iface.curr_buf).re_exponent and
+                temp_im = get_float_str true iface.gen_buffer.(iface.curr_buf).im_mantissa
+                iface.gen_buffer.(iface.curr_buf).im_exponent in
+                match iface.gen_buffer.(iface.curr_buf).is_polar with
+                |false ->
+                  ss := !ss ^ "(" ^ temp_re ^ ", " ^ temp_im ^ ")]]"
+                |true ->
+                  ss := !ss ^ "(" ^ temp_re ^ " <" ^ temp_im ^ ")]]"
+            else
+                let temp_re = get_float_str true iface.gen_buffer.(iface.curr_buf).re_mantissa
+                iface.gen_buffer.(iface.curr_buf).re_exponent in
+                ss := !ss ^ "(" ^ temp_re ^ ")]]");
+            if iface.is_entering_units then
+                !ss ^ "_" ^ iface.units_entry_buffer
+            else
+                !ss
+          |VarEntry ->
+            "@ " ^ iface.variable_entry_buffer
+      in
+      begin match iface.interface_mode with
+      |StandardEditMode ->
+          draw_entry_string data_string 0
+      |IntEditMode ->
+          draw_entry_string data_string 0
+      |AbbrevEditMode ->
+          let first_abbrev_match =
+            if iface.matched_abbrev_list = [] then ""
+            else List.hd iface.matched_abbrev_list
+          in
+          let highlight_len = String.length iface.abbrev_entry_buffer in
+          if highlight_len = 0 then
+            begin match iface.abbrev_or_const with
+            |IsAbbrev -> draw_entry_string "<enter command abbreviation>" 0
+            |IsConst  -> draw_entry_string "<enter constant symbol>" 0
+            end
+          else
+            begin match iface.abbrev_or_const with
+            |IsAbbrev ->
+                let is_function =
+                  match (Rcfile.translate_abbrev first_abbrev_match) with
+                  |Function ff -> true
+                  |_ -> false
+                in
+                if is_function then
+                  draw_entry_string (first_abbrev_match ^ "( )") highlight_len
+                else
+                  draw_entry_string first_abbrev_match highlight_len
+            |IsConst ->
+                draw_entry_string first_abbrev_match highlight_len
+            end
+      |BrowsingMode ->
+          ()
+      |VarEditMode ->
+          if String.length iface.variable_entry_buffer = 0 then
+            draw_entry_string "<enter variable name>" 0
+          else
+            draw_entry_string data_string 0
+      |UnitEditMode ->
+          draw_entry_string data_string 0
+      end;
+      assert (wmove iface.scr.entry_win (iface.scr.ew_lines - 1) (iface.scr.ew_cols - 1))
+   end
 
 
 let draw_update_entry iface =
@@ -654,29 +670,28 @@ let draw_help_browsing iface win mvwaddstr_safe try_find =
    try_find (Browse ScrollLeft));
    mvwaddstr_safe win 9 2  ("scroll right: " ^
    try_find (Browse ScrollRight));
-   mvwaddstr_safe win 10 2 ("swap down   : " ^
-   try_find (Browse SwapDown));
-   mvwaddstr_safe win 11 2 ("swap up     : " ^
+   mvwaddstr_safe win 10 2 ("swap down/up: " ^
+   try_find (Browse SwapDown) ^ " / " ^
    try_find (Browse SwapUp));
-   mvwaddstr_safe win 12 2 ("roll down   : " ^
+   mvwaddstr_safe win 11 2 ("roll down   : " ^
    try_find (Browse RollDown));
-   mvwaddstr_safe win 13 2 ("roll up     : " ^
+   mvwaddstr_safe win 12 2 ("roll up     : " ^
    try_find (Browse RollUp));
-   mvwaddstr_safe win 14 2 ("dup         : " ^
+   mvwaddstr_safe win 13 2 ("dup         : " ^
    try_find (Command Dup));
-   mvwaddstr_safe win 15 2 ("view        : " ^
+   mvwaddstr_safe win 14 2 ("view        : " ^
    try_find (Browse ViewEntry));
-   mvwaddstr_safe win 16 2 ("edit        : " ^
+   mvwaddstr_safe win 15 2 ("edit        : " ^
    try_find (Browse EditEntry));
-   mvwaddstr_safe win 17 2 ("drop        : " ^
+   mvwaddstr_safe win 16 2 ("drop        : " ^
    try_find (Browse Drop1));
-   mvwaddstr_safe win 18 2 ("dropn       : " ^
+   mvwaddstr_safe win 17 2 ("dropn       : " ^
    try_find (Browse DropN));
-   mvwaddstr_safe win 19 2 ("keep        : " ^
+   mvwaddstr_safe win 18 2 ("keep        : " ^
    try_find (Browse Keep));
-   mvwaddstr_safe win 20 2 ("keepn       : " ^
+   mvwaddstr_safe win 19 2 ("keepn       : " ^
    try_find (Browse KeepN));
-   mvwaddstr_safe win 22 1 ("exit browsing mode: " ^
+   mvwaddstr_safe win 21 1 ("exit browsing mode: " ^
    try_find (Browse EndBrowse));
    assert (wnoutrefresh win)
 
@@ -684,67 +699,76 @@ let draw_help_browsing iface win mvwaddstr_safe try_find =
 
 (* display the help window *)
 let draw_help (iface : interface_state_t) =
-   let mvwaddstr_safe w vert horiz st =
-      let st_trunc =
-         if String.length st > 36 then
-            Str.string_before st 36
-         else
-            st
-      in
-      assert (mvwaddstr w vert horiz st_trunc)
-   in
-   let modes = iface.calc#get_modes () in
-   begin match iface.scr.help_win with
-   |None ->
-      ()
-   |Some win ->
-      wclear win;
-      wattron win WA.bold;
-      let s = sprintf "Orpie v%s" iface.version in
-      mvwaddstr_safe win 0 0 s;
-      wattroff win WA.bold;
-      let h_pos = String.length s in
-      mvwaddstr_safe win 0 (h_pos + 1) ("-- " ^ iface.tagline);
-      assert (mvwaddstr win 1 0 "--------------------------------------");
-      for i = 0 to pred iface.scr.hw_lines do
-         assert (mvwaddch win i 38 (int_of_char '|'))
-      done;
-      wattron win WA.bold;
-      assert (mvwaddstr win 2 0 "Calculator Modes:");
-      assert (mvwaddstr win 3 2 "angle:      base:      complex:");
-      wattroff win WA.bold;
-      let angle_str = match modes.angle with
-      |Rad -> "RAD"
-      |Deg -> "DEG" in
-      assert (mvwaddstr win 3 9 angle_str);
-      let base_str = match modes.base with
-      |Bin -> "BIN"
-      |Oct -> "OCT"
-      |Hex -> "HEX"
-      |Dec -> "DEC" in
-      assert (mvwaddstr win 3 20 base_str);
-      let complex_str = match modes.complex with
-      |Rect -> "REC"
-      |Polar -> "POL" in
-      assert (mvwaddstr win 3 34 complex_str);
-      let try_find op =
-         try Rcfile.key_of_operation op
-         with Not_found -> "(N/A)"
-      in
-      begin match iface.interface_mode with
-      |StandardEditMode | UnitEditMode -> 
-         draw_help_standard iface win mvwaddstr_safe try_find
-      |IntEditMode ->
-         draw_help_intedit iface win mvwaddstr_safe try_find
-      |AbbrevEditMode ->
-         draw_help_abbrev iface win mvwaddstr_safe try_find
-      |VarEditMode ->
-         draw_help_varedit iface win mvwaddstr_safe try_find
-      |BrowsingMode ->
-         draw_help_browsing iface win mvwaddstr_safe try_find
-      end
-   end; 
-   assert (wmove iface.scr.entry_win (iface.scr.ew_lines - 1) (iface.scr.ew_cols - 1))
+  if iface.scr.is_paused then
+   begin
+    Printf.fprintf stderr "Orpie requires at least an 80x24 line window.\r\n";
+    flush stderr;
+   end
+   else
+   begin
+    let mvwaddstr_safe w vert horiz st =
+        let st_trunc =
+          if String.length st > 36 then
+              Str.string_before st 36
+          else
+              st
+        in
+        assert (mvwaddstr w vert horiz st_trunc)
+    in
+    let modes = iface.calc#get_modes () in
+    begin match iface.scr.help_win with
+    |None ->
+        ()
+    |Some win ->
+        wclear win;
+        wattron win WA.bold;
+        let s = sprintf "Orpie v%s" iface.version in
+        mvwaddstr_safe win 0 0 s;
+        wattroff win WA.bold;
+        let h_pos = String.length s in
+        mvwaddstr_safe win 0 (h_pos + 1) ("-- " ^ iface.tagline);
+        assert (mvwaddstr win 1 0 "--------------------------------------");
+        for i = 0 to pred iface.scr.hw_lines do
+          assert (mvwaddch win i 38 (int_of_char '|'))
+        done;
+        wattron win WA.bold;
+        assert (mvwaddstr win 2 0 "Calculator Modes:");
+        assert (mvwaddstr win 3 2 "angle:      base:      complex:");
+        wattroff win WA.bold;
+        let angle_str = match modes.angle with
+        |Rad -> "RAD"
+        |Deg -> "DEG" in
+        assert (mvwaddstr win 3 9 angle_str);
+        let base_str = match modes.base with
+        |Bin -> "BIN"
+        |Oct -> "OCT"
+        |Hex -> "HEX"
+        |Dec -> "DEC" in
+        assert (mvwaddstr win 3 20 base_str);
+        let complex_str = match modes.complex with
+        |Rect -> "REC"
+        |Polar -> "POL" in
+        assert (mvwaddstr win 3 34 complex_str);
+        let try_find op =
+          try Rcfile.key_of_operation op
+          with Not_found -> "(N/A)"
+        in
+        begin match iface.interface_mode with
+        |StandardEditMode | UnitEditMode -> 
+          draw_help_standard iface win mvwaddstr_safe try_find
+        |IntEditMode ->
+          draw_help_intedit iface win mvwaddstr_safe try_find
+        |AbbrevEditMode ->
+          draw_help_abbrev iface win mvwaddstr_safe try_find
+        |VarEditMode ->
+          draw_help_varedit iface win mvwaddstr_safe try_find
+        |BrowsingMode ->
+          draw_help_browsing iface win mvwaddstr_safe try_find
+        end
+    end;
+    assert (wmove iface.scr.entry_win (iface.scr.ew_lines - 1) (iface.scr.ew_cols - 1));
+   end
+
 
 
 let draw_message (iface : interface_state_t) msg =

--- a/src/orpie/interface_main.ml
+++ b/src/orpie/interface_main.ml
@@ -1081,6 +1081,26 @@ let handle_next_line (iface : interface_state_t) =
       ()
 
 
+(* handle swap up in browsing mode *)
+let handle_swapup (iface : interface_state_t) =
+   if iface.stack_selection < iface.calc#get_stack_size () then
+      (iface.calc#swapup iface.stack_selection;
+      handle_prev_line iface;
+      draw_update_stack iface)
+   else
+      ()
+
+
+(* handle swap down in browsing mode *)
+let handle_swapdown (iface : interface_state_t) =
+   if iface.stack_selection > 1 then
+      (iface.calc#swapdown iface.stack_selection;
+      handle_next_line iface;
+      draw_update_stack iface)
+   else
+      ()
+
+
 (* handle echoing stack selection (browsing mode) *)
 let handle_browse_echo (iface : interface_state_t) =
    iface.calc#echo iface.stack_selection;
@@ -2046,6 +2066,10 @@ let handle_keypress_browse key (iface : interface_state_t) =
          handle_scroll_left iface
       |ScrollRight ->
          handle_scroll_right iface
+      |SwapDown ->
+         handle_swapdown iface
+      |SwapUp ->
+         handle_swapup iface
       |RollDown ->
          handle_rolldown iface
       |RollUp ->

--- a/src/orpie/operations.ml
+++ b/src/orpie/operations.ml
@@ -49,7 +49,8 @@ type edit_operation_t     = | Digit | Enter | Backspace | Minus | SciNotBase
                             | Separator | Angle | BeginUnits;;
 
 type browse_operation_t   = | EndBrowse
-                            | ScrollLeft | ScrollRight | RollDown | RollUp
+                            | ScrollLeft | ScrollRight
+                            | SwapDown | SwapUp | RollDown | RollUp
                             | PrevLine | NextLine | Echo | ViewEntry
                             | Drop1 | DropN | Keep | KeepN
                             | EditEntry;;

--- a/src/orpie/rcfile.ml
+++ b/src/orpie/rcfile.ml
@@ -544,6 +544,8 @@ let operation_of_string command_str =
    |"browse_prev_line"              -> (Browse PrevLine)
    |"browse_next_line"              -> (Browse NextLine)
    |"browse_echo"                   -> (Browse Echo)
+   |"browse_swapdown"               -> (Browse SwapDown)
+   |"browse_swapup"                 -> (Browse SwapUp)
    |"browse_rolldown"               -> (Browse RollDown)
    |"browse_rollup"                 -> (Browse RollUp)
    |"browse_view"                   -> (Browse ViewEntry)

--- a/src/orpie/rpc_calc.ml
+++ b/src/orpie/rpc_calc.ml
@@ -1578,6 +1578,12 @@ class rpc_calc conserve_memory =
       method rollup i =
          stack#rollup i
 
+      method swapdown i =
+         stack#swapdown i
+
+      method swapup i =
+         stack#swapup i
+
       method delete i = 
          stack#delete i
 

--- a/src/orpie/rpc_stack.ml
+++ b/src/orpie/rpc_stack.ml
@@ -255,6 +255,28 @@ class rpc_stack conserve_memory_in =
             raise (Invalid_argument "cannot echo nonexistant element")
 
 
+      (* swap element `num` with element down from it (i.e. towards the top
+       * of the stack). *)
+      method swapdown num =
+         if (len - num) < len-1 then
+            let temp = stack.(len - num) in
+            stack.(len - num) <- stack.(len - num + 1);
+            stack.(len - num + 1) <- temp
+         else
+            raise (Stack_error "cannot swap down at bottom");
+
+
+      (* swap element `num` with element up from it (i.e. away from the top
+       * of the stack). *)
+       method swapup num =
+         if (len - num) > 0 then
+            let temp = stack.(len - num) in
+            stack.(len - num) <- stack.(len - num - 1);
+            stack.(len - num - 1) <- temp
+         else
+            raise (Stack_error "cannot swap up at top");
+
+
       (* cyclically roll all stack elements downward (i.e. towards the top
        * of the stack), starting below element number 'num' (inclusive). *)
       method rolldown num =


### PR DESCRIPTION
It got annoying, accidentally resizing my terminal window and orpie crashing if I made it too small.  So now it just shows an error until you make it big enough again.  Also, includes my "move items around in the list" changes, and some changes others made that seemed good to pull in.